### PR TITLE
Ticket uppdatering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -936,7 +936,6 @@
       "integrity": "sha512-Kmpl+z84ILoG+3T/zQFyAJsU6EPTmOCj8/2+83fSN6djd6I4o7uOuGIH6vq3PrjY5BGitSbFuMN18j3iknubbA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1001,7 +1000,6 @@
       "integrity": "sha512-VGMpFQGUQWYT9LfnPcX8ouFojyrZ/2w3K5BucvxL/spdNehccKhB4jUyB1yBCXpr2XFm0jkECxgrpXBW2ipoAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.44.0",
         "@typescript-eslint/types": "8.44.0",
@@ -1207,7 +1205,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1890,7 +1887,6 @@
       "integrity": "sha512-hB4FIzXovouYzwzECDcUkJ4OcfOEkXTv2zRY6B9bkwjx/cprAq0uvm1nl7zvQ0/TsUk0zQiN4uPfJpB9m+rPMQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4476,7 +4472,6 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,10 +47,13 @@ import type {
   TicketsFindAllOptions,
   TicketsFindOptions,
   TicketsCreateOptions,
+  TicketsUpdateOptions,
   StaticTicketsFindAllOptions,
   StaticTicketsFindOptions,
   StaticTicketsCreateOptions,
+  StaticTicketsUpdateOptions,
   TicketCreateData,
+  TicketUpdateData,
 } from './schemas/ticket.js'
 import type {
   WebhooksFindAllOptions,
@@ -117,6 +120,9 @@ class Confetti {
     create: (json: TicketCreateData, options: TicketsCreateOptions = {}) => {
       return ticketsResource.create(json, options, this.adapter)
     },
+    update: (id: string | number, json: TicketUpdateData, options: TicketsUpdateOptions = {}) => {
+      return ticketsResource.update(id, json, options, this.adapter)
+    },
   }
   static tickets = {
     findAll: (options: StaticTicketsFindAllOptions) => {
@@ -127,6 +133,9 @@ class Confetti {
     },
     create: (json: TicketCreateData, options: StaticTicketsCreateOptions) => {
       return ticketsResource.create(json, options, adapter(options))
+    },
+    update: (id: string | number, json: TicketUpdateData, options: StaticTicketsUpdateOptions) => {
+      return ticketsResource.update(id, json, options, adapter(options))
     },
   }
 

--- a/src/models/ticket.ts
+++ b/src/models/ticket.ts
@@ -1,6 +1,6 @@
 import loadSamples from '../utils/load-samples.js'
 import { schemaToAttributes, schemaToCreateAttributes } from '../utils/schema-to-attributes.js'
-import { TicketSchema, TicketCreateSchema } from '../schemas/ticket.js'
+import { TicketSchema, TicketCreateSchema, TicketUpdateSchema } from '../schemas/ticket.js'
 import { ModelDefinition } from '../types/model.js'
 import {
   extractFiltersFromSchema,
@@ -27,6 +27,10 @@ export default function TicketModel(): ModelDefinition {
       create: {
         schema: TicketCreateSchema,
         attributes: schemaToCreateAttributes(TicketCreateSchema),
+      },
+      update: {
+        schema: TicketUpdateSchema,
+        attributes: schemaToCreateAttributes(TicketUpdateSchema),
       },
     },
     webhooks: [

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -18,7 +18,9 @@ import {
   type TicketsFindAllOptions,
   type TicketsFindOptions,
   type TicketsCreateOptions,
+  type TicketsUpdateOptions,
   type TicketCreateData,
+  type TicketUpdateData,
 } from './schemas/ticket.js'
 import {
   paymentsFindAllOptionsSchema,
@@ -91,6 +93,24 @@ export const ticketsResource = {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/consistent-type-assertions
       json: validatedData as any,
       path: models.ticket.path,
+      type: models.ticket.endpoint,
+      ...validatedOptions,
+    })
+  },
+  update: (
+    id: string | number,
+    json: TicketUpdateData,
+    options: TicketsUpdateOptions = {},
+    adapter: Adapter,
+  ): Promise<Ticket> => {
+    const validatedOptions = baseOptionsSchema.parse(options)
+    if (!models.ticket.operations.update) throw new Error('Ticket update operation not found')
+    const validatedData = models.ticket.operations.update.schema.parse(json)
+
+    return adapter.put<Ticket>({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/consistent-type-assertions
+      json: validatedData as any,
+      path: `${models.ticket.path}/${id}`,
       type: models.ticket.endpoint,
       ...validatedOptions,
     })

--- a/src/schemas/ticket.ts
+++ b/src/schemas/ticket.ts
@@ -231,6 +231,15 @@ export const TicketUpdateSchema = z.object({
         label: 'Comment',
       }),
     ),
+  values: z
+    .looseObject({})
+    .optional()
+    .describe(
+      JSON.stringify({
+        label: 'Values',
+        helpText: 'Custom field values for the ticket.',
+      }),
+    ),
   sendEmailConfirmation: z
     .boolean()
     .optional()

--- a/src/schemas/ticket.ts
+++ b/src/schemas/ticket.ts
@@ -3,6 +3,7 @@ import {
   baseFindAllOptionsSchema,
   staticBaseFindAllOptionsSchema,
   baseOptionsSchema,
+  staticBaseOptionsSchema,
   staticBaseFindOptionsSchema,
   findBaseOptionsSchema,
 } from './resource-options.js'
@@ -159,6 +160,86 @@ export const TicketSchema = z.object({
       label: 'Contact Id',
     }),
   ),
+})
+
+export const TicketUpdateSchema = z.object({
+  firstName: z
+    .string()
+    .optional()
+    .describe(
+      JSON.stringify({
+        label: 'First name',
+      }),
+    ),
+  lastName: z
+    .string()
+    .optional()
+    .describe(
+      JSON.stringify({
+        label: 'Last name',
+      }),
+    ),
+  email: z
+    .string()
+    .optional()
+    .describe(
+      JSON.stringify({
+        label: 'Email',
+      }),
+    ),
+  status: z
+    .union([
+      z.string().refine(
+        (val) => {
+          const values = val.split(',').map((v) => v.trim())
+          return values.every((v) => v === 'attending' || v === 'invited' || v === 'declined' || v === 'waitlist')
+        },
+        { message: 'Status must be "attending", "invited", "declined", "waitlist", or a comma-separated list of these values' },
+      ),
+      z.array(z.enum(['attending', 'invited', 'declined', 'waitlist'])),
+    ])
+    .optional()
+    .describe(
+      JSON.stringify({
+        label: 'Status',
+        values: ['attending', 'invited', 'declined', 'waitlist'],
+      }),
+    ),
+  phone: z
+    .string()
+    .optional()
+    .describe(
+      JSON.stringify({
+        label: 'Phone',
+        placeholder: '+46 12 345 67 89',
+        helpText: 'Mobile phone number with country code. Example: +46701234567',
+      }),
+    ),
+  company: z
+    .string()
+    .optional()
+    .describe(
+      JSON.stringify({
+        label: 'Company',
+      }),
+    ),
+  comment: z
+    .string()
+    .optional()
+    .describe(
+      JSON.stringify({
+        label: 'Comment',
+      }),
+    ),
+  sendEmailConfirmation: z
+    .boolean()
+    .optional()
+    .describe(
+      JSON.stringify({
+        label: 'Send email confirmation',
+        helpText: 'If set to true, an email confirmation will be sent to the attendee / invitee.',
+      }),
+    ),
 })
 
 export const TicketCreateSchema = z.object({
@@ -406,13 +487,18 @@ export const ticketsFindOptionsSchema = findBaseOptionsSchema.extend({})
 export const staticTicketsFindAllOptionsSchema = staticBaseFindAllOptionsSchema.extend(ticketsFindAllSchema)
 export const staticTicketsFindOptionsSchema = staticBaseFindOptionsSchema.extend({})
 export const staticTicketsCreateOptionsSchema = staticBaseFindAllOptionsSchema.extend({})
+export const staticTicketsUpdateOptionsSchema = staticBaseOptionsSchema.extend({})
 
 export type Ticket = z.infer<typeof TicketSchema>
 export type TicketCreate = z.infer<typeof TicketCreateSchema>
 export type TicketCreateData = z.infer<typeof TicketCreateSchema>
+export type TicketUpdate = z.infer<typeof TicketUpdateSchema>
+export type TicketUpdateData = z.infer<typeof TicketUpdateSchema>
 export type TicketsFindAllOptions = z.infer<typeof ticketsFindAllOptionsSchema>
 export type TicketsFindOptions = z.infer<typeof ticketsFindOptionsSchema>
 export type TicketsCreateOptions = z.infer<typeof baseOptionsSchema>
+export type TicketsUpdateOptions = z.infer<typeof baseOptionsSchema>
 export type StaticTicketsFindAllOptions = z.infer<typeof staticTicketsFindAllOptionsSchema>
 export type StaticTicketsFindOptions = z.infer<typeof staticTicketsFindOptionsSchema>
 export type StaticTicketsCreateOptions = z.infer<typeof staticTicketsCreateOptionsSchema>
+export type StaticTicketsUpdateOptions = z.infer<typeof staticTicketsUpdateOptionsSchema>

--- a/test/resources/tickets.ts
+++ b/test/resources/tickets.ts
@@ -59,6 +59,23 @@ describe('Tickets', () => {
 
       assert.deepStrictEqual(data, Confetti.models.ticket.sample.single.formatted)
     })
+
+    test('should update a ticket', async () => {
+      const mockData = Confetti.models.ticket.sample.single.raw
+
+      nock('https://api.confetti.events')
+        .put('/tickets/1')
+        .reply(200, mockData as MockResponseData)
+
+      const confetti = new Confetti({ apiKey: 'my-key' })
+      const data = await confetti.tickets.update(1, {
+        firstName: 'Jane',
+        lastName: 'Doe',
+        email: 'jane@doe.se',
+      })
+
+      assert.deepStrictEqual(data, Confetti.models.ticket.sample.single.formatted)
+    })
   })
 
   describe('Static', () => {
@@ -126,6 +143,26 @@ describe('Tickets', () => {
           email: 'john@doe.se',
           company: 'Company AB',
           sendEmailConfirmation: true,
+        },
+        { apiKey: 'my-key' },
+      )
+      assert.deepStrictEqual(data, Confetti.models.ticket.sample.single.formatted)
+    })
+
+    test('should update a ticket', async () => {
+      const mockData = Confetti.models.ticket.sample.single.raw
+
+      nock('https://api.confetti.events')
+        .put('/tickets/1')
+        .reply(200, mockData as MockResponseData)
+
+      const data = await Confetti.tickets.update(
+        1,
+        {
+          firstName: 'Jane',
+          lastName: 'Doe',
+          email: 'jane@doe.se',
+          status: 'attending',
         },
         { apiKey: 'my-key' },
       )


### PR DESCRIPTION
Add PUT/update functionality for tickets.

This PR introduces the ability to update a ticket using a PUT operation, as requested by the user.

**Changes:**

*   **`src/schemas/ticket.ts`**: Added `TicketUpdateSchema` with optional updatable fields (`firstName`, `lastName`, `email`, `status`, `phone`, `company`, `comment`, `sendEmailConfirmation`) and related types (`TicketUpdateData`, `TicketsUpdateOptions`, `StaticTicketsUpdateOptions`). Also imported `staticBaseOptionsSchema`.
*   **`src/models/ticket.ts`**: Integrated the `update` operation into the ticket model definition.
*   **`src/resources.ts`**: Added the `update` method to `ticketsResource`, utilizing `adapter.put()` for `PUT /tickets/:id`.
*   **`src/index.ts`**: Exposed the `update` method on both instance and static `Confetti.tickets`.
*   **`test/resources/tickets.ts`**: Added new tests for both instance and static ticket update operations.

**Usage:**

```typescript
// Instance
const confetti = new Confetti({ apiKey: 'key' })
await confetti.tickets.update(1, {
  firstName: 'Jane',
  lastName: 'Doe',
  email: 'jane@doe.se',
  status: 'attending',
})

// Static
await Confetti.tickets.update(1, { firstName: 'Jane' }, { apiKey: 'key' })
```

---
<p><a href="https://cursor.com/agents/bc-5f5b3d70-6fa6-42f3-a1de-8f9207055401"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5f5b3d70-6fa6-42f3-a1de-8f9207055401"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

