### PR TITLE
Add ticket update support and guest ticket management

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+save-exact=true
+save-prefix=
+min-release-age=7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+# 4.1.0
+
+- Feature: `tickets.update(id, data, options)` for editing tickets after create.
+- Feature: tickets can now be created with inline `guestTickets` — an array of guest people that become child tickets attached to the parent. Each guest accepts `firstName`, `lastName`, `email`, `phone`, `company`, and `values`. Requires the event to have guest info enabled. Guests can only be set at create time; editing or removing guests on an existing ticket is not yet supported by the API.
+- Feature: tickets now expose `parentTicket` (the parent of a guest ticket) and `guestTickets` (the guests of a parent ticket) as includable relations.
+- Feature: ticket `values` (raw form field answers keyed by field name) can now be set on both create and update.
+- Change: form field `name` is auto-generated from `title` when omitted on create, and is now treated as immutable — it is no longer accepted by `formFields.update`.
+
+# 4.0.0 - 2026-06-01
+
+- Feature: write-side CRUD added across the SDK — `events.update`, full CRUD for `pages`, `blocks`, `images`, `formFields`, `speakers`, `organisers`, `scheduleItems`, `sponsors`, `sponsorLevels`, plus read-only `forms` and `formFields`.
+- Feature: image uploads supported via `images.create`.
+- Feature: every model now exposes Zod schemas at `model.operations.{read,create,update}.schema`, and a `schemaToJsonSchema()` utility converts them to JSON Schema for tools like MCP.
+- Feature: events expose `customCss`, a `workspace` relationship, and a tightened `location` schema.
+- Feature: new `previewToken` model.
+- Change: model attribute metadata moved from `model.attributes` to `model.operations.read.attributes`.
+- Change: model field descriptions migrated from `.describe(JSON.stringify(...))` to native Zod `.meta()`, including `label`, `description`, `helpText`, and enum `values` for tooling.
+- Change: blocks and images use `type` instead of `blockType` / `imageType`.
+- Change: yayson upgraded to v4; the SDK uses typed presenters and store symbols internally.
+- Change: dependency versions pinned (caret ranges dropped) for reproducible installs.
+
 # 3.0.5 - 2026-05-20
 
 - Fix: accept both string and number ids on write-side `*Id` fields (create, update, filter). JSON:API returns ids as strings, so values from `findAll` can now be passed straight into `create` without a `ZodError`. Uses `z.coerce.number()` — numeric callers keep working.

--- a/README.md
+++ b/README.md
@@ -68,11 +68,21 @@ const events = await confetti.events.findAll({
 
 ## Resources
 
-- **Events** - `findAll`, `find`
+- **Events** - `findAll`, `find`, `create`, `update`
+- **Tickets** - `findAll`, `find`, `create`, `update`
 - **Contacts** - `findAll`, `find`, `create`
-- **Tickets** - `findAll`, `find`, `create`
-- **Payments** - `findAll`, `find`
+- **Pages** - `findAll`, `find`, `create`, `update`, `delete`
+- **Blocks** - `findAll`, `find`, `create`, `update`, `delete`
+- **Images** - `findAll`, `find`, `create`, `update`, `delete`
+- **Forms** - `findAll`, `find`
+- **FormFields** - `findAll`, `find`, `create`, `update`, `delete`
+- **Speakers** - `findAll`, `find`, `create`, `update`, `delete`
+- **Organisers** - `findAll`, `find`, `create`, `update`, `delete`
+- **ScheduleItems** - `findAll`, `find`, `create`, `update`, `delete`
+- **Sponsors** - `findAll`, `find`, `create`, `update`, `delete`
+- **SponsorLevels** - `findAll`, `find`, `create`, `update`, `delete`
 - **Webhooks** - `findAll`, `find`, `create`, `delete`
+- **Payments** - `findAll`, `find`
 - **Workspaces** - `findAll`, `find`
 - **Categories** - `findAll`, `find`
 - **TicketBatches** - `findAll`, `find`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "confetti",
-  "version": "4.0.0-rc.0",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "confetti",
-      "version": "4.0.0-rc.0",
+      "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
         "node-fetch": "3.3.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "confetti",
-  "version": "3.0.5",
+  "version": "4.0.0-rc.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "confetti",
-      "version": "3.0.5",
+      "version": "4.0.0-rc.0",
       "license": "MIT",
       "dependencies": {
         "node-fetch": "3.3.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "node-fetch": "3.3.2",
         "qs": "6.14.0",
-        "yayson": "4.1.0",
+        "yayson": "4.2.0",
         "zod": "4.1.11"
       },
       "devDependencies": {
@@ -4775,9 +4775,9 @@
       }
     },
     "node_modules/yayson": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/yayson/-/yayson-4.1.0.tgz",
-      "integrity": "sha512-fnqXKIaHYA5cO5VqbkMGwpsLZZa6016HrEVAA6iZl7JWX40REe/wx7Ql2Nf7wOB4Wwc8PQiJ5ldWWVLVUn1iww==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/yayson/-/yayson-4.2.0.tgz",
+      "integrity": "sha512-0bxq30zmlJQi50A1pkim5/3Ugq3WHHgE2rsqZj1pwu8/GWSHZ4v4e0D3mJw+Bn4UjqReA0KlEkrpZMRYpzFyuQ==",
       "license": "MIT",
       "engines": {
         "node": ">=20",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   "dependencies": {
     "node-fetch": "3.3.2",
     "qs": "6.14.0",
-    "yayson": "4.1.0",
+    "yayson": "4.2.0",
     "zod": "4.1.11"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "confetti",
-  "version": "4.0.0-rc.0",
+  "version": "4.0.0",
   "description": "A Node wrapper for the Confetti API.",
   "type": "module",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "confetti",
-  "version": "3.0.5",
+  "version": "4.0.0-rc.0",
   "description": "A Node wrapper for the Confetti API.",
   "type": "module",
   "exports": {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -30,7 +30,22 @@ export class NotFoundError extends Error {
   }
 }
 
+export class OperationNotFoundError extends Error {
+  public errorType: string
+
+  constructor(message: string, options: ErrorOptions = {}) {
+    super(message)
+    this.name = 'OperationNotFoundError'
+    this.errorType = message
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor)
+    }
+    Object.assign(this, options)
+  }
+}
+
 export default {
   ParameterError,
   NotFoundError,
+  OperationNotFoundError,
 }

--- a/src/models/ticket.ts
+++ b/src/models/ticket.ts
@@ -36,6 +36,7 @@ export default function TicketModel(): ModelDefinition {
     relationships: [
       { field: 'eventId', relationship: 'event', type: 'belongsTo' },
       { field: 'ticketBatchId', relationship: 'ticketBatch', type: 'belongsTo' },
+      { field: 'parentTicketId', relationship: 'parentTicket', type: 'belongsTo' },
     ],
     meta: [{ field: 'sendEmailConfirmation', key: 'sendEmailConfirmation' }],
     webhooks: [

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -147,6 +147,7 @@ import {
 import { baseOptionsSchema } from './schemas/resource-options.js'
 
 import { Adapter } from './adapter.js'
+import { OperationNotFoundError } from './errors.js'
 import {
   Event,
   Contact,
@@ -180,7 +181,7 @@ export const eventsResource = {
   },
   create: (json: EventCreateData, options: EventsCreateOptions = {}, adapter: Adapter): Promise<Event> => {
     const validatedOptions = baseOptionsSchema.parse(options)
-    if (!models.event.operations.create) throw new Error('Event create operation not found')
+    if (!models.event.operations.create) throw new OperationNotFoundError('Event create operation not found')
     const validatedData = models.event.operations.create.schema.parse(json)
     return adapter.post<Event>({
       json: validatedData,
@@ -196,7 +197,7 @@ export const eventsResource = {
     adapter: Adapter,
   ): Promise<Event> => {
     const validatedOptions = baseOptionsSchema.parse(options)
-    if (!models.event.operations.update) throw new Error('Event update operation not found')
+    if (!models.event.operations.update) throw new OperationNotFoundError('Event update operation not found')
     const validatedData = models.event.operations.update.schema.parse(json)
     return adapter.put<Event>({
       json: validatedData,
@@ -222,7 +223,7 @@ export const ticketsResource = {
   },
   create: (json: TicketCreateData, options: TicketsCreateOptions = {}, adapter: Adapter): Promise<Ticket> => {
     const validatedOptions = baseOptionsSchema.parse(options)
-    if (!models.ticket.operations.create) throw new Error('Ticket create operation not found')
+    if (!models.ticket.operations.create) throw new OperationNotFoundError('Ticket create operation not found')
     const validatedData = models.ticket.operations.create.schema.parse(json)
 
     return adapter.post<Ticket>({
@@ -239,7 +240,7 @@ export const ticketsResource = {
     adapter: Adapter,
   ): Promise<Ticket> => {
     const validatedOptions = baseOptionsSchema.parse(options)
-    if (!models.ticket.operations.update) throw new Error('Ticket update operation not found')
+    if (!models.ticket.operations.update) throw new OperationNotFoundError('Ticket update operation not found')
     const validatedData = models.ticket.operations.update.schema.parse(json)
     return adapter.put<Ticket>({
       json: validatedData,
@@ -265,7 +266,7 @@ export const contactsResource = {
   },
   create: (json: ContactCreateData, options: ContactsCreateOptions = {}, adapter: Adapter): Promise<Contact> => {
     const validatedOptions = baseOptionsSchema.parse(options)
-    if (!models.contact.operations.create) throw new Error('Contact create operation not found')
+    if (!models.contact.operations.create) throw new OperationNotFoundError('Contact create operation not found')
     const validatedData = models.contact.operations.create.schema.parse(json)
 
     return adapter.post<Contact>({
@@ -307,7 +308,7 @@ export const webhooksResource = {
   },
   create: (json: WebhookCreateData, options: WebhooksCreateOptions = {}, adapter: Adapter): Promise<Webhook> => {
     const validatedOptions = baseOptionsSchema.parse(options)
-    if (!models.webhook.operations.create) throw new Error('Webhook create operation not found')
+    if (!models.webhook.operations.create) throw new OperationNotFoundError('Webhook create operation not found')
     const validatedData = models.webhook.operations.create.schema.parse(json)
     return adapter.post<Webhook>({
       path: models.webhook.path,
@@ -394,7 +395,7 @@ export const pagesResource = {
   },
   create: (json: PageCreateData, options: PagesCreateOptions = {}, adapter: Adapter): Promise<Page> => {
     const validatedOptions = baseOptionsSchema.parse(options)
-    if (!models.page.operations.create) throw new Error('Page create operation not found')
+    if (!models.page.operations.create) throw new OperationNotFoundError('Page create operation not found')
     const validatedData = models.page.operations.create.schema.parse(json)
     return adapter.post<Page>({
       json: validatedData,
@@ -410,7 +411,7 @@ export const pagesResource = {
     adapter: Adapter,
   ): Promise<Page> => {
     const validatedOptions = baseOptionsSchema.parse(options)
-    if (!models.page.operations.update) throw new Error('Page update operation not found')
+    if (!models.page.operations.update) throw new OperationNotFoundError('Page update operation not found')
     const validatedData = models.page.operations.update.schema.parse(json)
     return adapter.put<Page>({
       json: validatedData,
@@ -444,7 +445,7 @@ export const blocksResource = {
   },
   create: (json: BlockCreateData, options: BlocksCreateOptions = {}, adapter: Adapter): Promise<Block> => {
     const validatedOptions = baseOptionsSchema.parse(options)
-    if (!models.block.operations.create) throw new Error('Block create operation not found')
+    if (!models.block.operations.create) throw new OperationNotFoundError('Block create operation not found')
     const validatedData = models.block.operations.create.schema.parse(json)
     return adapter.post<Block>({
       json: validatedData,
@@ -460,7 +461,7 @@ export const blocksResource = {
     adapter: Adapter,
   ): Promise<Block> => {
     const validatedOptions = baseOptionsSchema.parse(options)
-    if (!models.block.operations.update) throw new Error('Block update operation not found')
+    if (!models.block.operations.update) throw new OperationNotFoundError('Block update operation not found')
     const validatedData = models.block.operations.update.schema.parse(json)
     return adapter.put<Block>({
       json: validatedData,
@@ -494,7 +495,7 @@ export const imagesResource = {
   },
   create: (json: ImageCreateData, options: ImagesCreateOptions = {}, adapter: Adapter): Promise<Image> => {
     const validatedOptions = baseOptionsSchema.parse(options)
-    if (!models.image.operations.create) throw new Error('Image create operation not found')
+    if (!models.image.operations.create) throw new OperationNotFoundError('Image create operation not found')
     const validatedData = models.image.operations.create.schema.parse(json)
     return adapter.post<Image>({
       json: validatedData,
@@ -510,7 +511,7 @@ export const imagesResource = {
     adapter: Adapter,
   ): Promise<Image> => {
     const validatedOptions = baseOptionsSchema.parse(options)
-    if (!models.image.operations.update) throw new Error('Image update operation not found')
+    if (!models.image.operations.update) throw new OperationNotFoundError('Image update operation not found')
     const validatedData = models.image.operations.update.schema.parse(json)
     return adapter.put<Image>({
       json: validatedData,
@@ -555,7 +556,7 @@ export const speakersResource = {
   },
   create: (json: SpeakerCreateData, options: SpeakersCreateOptions = {}, adapter: Adapter): Promise<Speaker> => {
     const validatedOptions = baseOptionsSchema.parse(options)
-    if (!models.speaker.operations.create) throw new Error('Speaker create operation not found')
+    if (!models.speaker.operations.create) throw new OperationNotFoundError('Speaker create operation not found')
     const validatedData = models.speaker.operations.create.schema.parse(json)
     return adapter.post<Speaker>({
       json: validatedData,
@@ -571,7 +572,7 @@ export const speakersResource = {
     adapter: Adapter,
   ): Promise<Speaker> => {
     const validatedOptions = baseOptionsSchema.parse(options)
-    if (!models.speaker.operations.update) throw new Error('Speaker update operation not found')
+    if (!models.speaker.operations.update) throw new OperationNotFoundError('Speaker update operation not found')
     const validatedData = models.speaker.operations.update.schema.parse(json)
     return adapter.put<Speaker>({
       json: validatedData,
@@ -613,7 +614,7 @@ export const formFieldsResource = {
     adapter: Adapter,
   ): Promise<FormField> => {
     const validatedOptions = baseOptionsSchema.parse(options)
-    if (!models.formField.operations.create) throw new Error('FormField create operation not found')
+    if (!models.formField.operations.create) throw new OperationNotFoundError('FormField create operation not found')
     const validatedData = models.formField.operations.create.schema.parse(json)
     return adapter.post<FormField>({
       json: validatedData,
@@ -629,7 +630,7 @@ export const formFieldsResource = {
     adapter: Adapter,
   ): Promise<FormField> => {
     const validatedOptions = baseOptionsSchema.parse(options)
-    if (!models.formField.operations.update) throw new Error('FormField update operation not found')
+    if (!models.formField.operations.update) throw new OperationNotFoundError('FormField update operation not found')
     const validatedData = models.formField.operations.update.schema.parse(json)
     return adapter.put<FormField>({
       json: validatedData,
@@ -659,7 +660,7 @@ export const organisersResource = {
   },
   create: (json: OrganiserCreateData, options: OrganisersCreateOptions = {}, adapter: Adapter): Promise<Organiser> => {
     const validatedOptions = baseOptionsSchema.parse(options)
-    if (!models.organiser.operations.create) throw new Error('Organiser create operation not found')
+    if (!models.organiser.operations.create) throw new OperationNotFoundError('Organiser create operation not found')
     const validatedData = models.organiser.operations.create.schema.parse(json)
     return adapter.post<Organiser>({
       json: validatedData,
@@ -675,7 +676,7 @@ export const organisersResource = {
     adapter: Adapter,
   ): Promise<Organiser> => {
     const validatedOptions = baseOptionsSchema.parse(options)
-    if (!models.organiser.operations.update) throw new Error('Organiser update operation not found')
+    if (!models.organiser.operations.update) throw new OperationNotFoundError('Organiser update operation not found')
     const validatedData = models.organiser.operations.update.schema.parse(json)
     return adapter.put<Organiser>({
       json: validatedData,
@@ -709,7 +710,7 @@ export const scheduleItemsResource = {
     adapter: Adapter,
   ): Promise<ScheduleItem> => {
     const validatedOptions = baseOptionsSchema.parse(options)
-    if (!models.scheduleItem.operations.create) throw new Error('ScheduleItem create operation not found')
+    if (!models.scheduleItem.operations.create) throw new OperationNotFoundError('ScheduleItem create operation not found')
     const validatedData = models.scheduleItem.operations.create.schema.parse(json)
     return adapter.post<ScheduleItem>({
       json: validatedData,
@@ -725,7 +726,7 @@ export const scheduleItemsResource = {
     adapter: Adapter,
   ): Promise<ScheduleItem> => {
     const validatedOptions = baseOptionsSchema.parse(options)
-    if (!models.scheduleItem.operations.update) throw new Error('ScheduleItem update operation not found')
+    if (!models.scheduleItem.operations.update) throw new OperationNotFoundError('ScheduleItem update operation not found')
     const validatedData = models.scheduleItem.operations.update.schema.parse(json)
     return adapter.put<ScheduleItem>({
       json: validatedData,
@@ -755,7 +756,7 @@ export const sponsorsResource = {
   },
   create: (json: SponsorCreateData, options: SponsorsCreateOptions = {}, adapter: Adapter): Promise<Sponsor> => {
     const validatedOptions = baseOptionsSchema.parse(options)
-    if (!models.sponsor.operations.create) throw new Error('Sponsor create operation not found')
+    if (!models.sponsor.operations.create) throw new OperationNotFoundError('Sponsor create operation not found')
     const validatedData = models.sponsor.operations.create.schema.parse(json)
     return adapter.post<Sponsor>({
       json: validatedData,
@@ -771,7 +772,7 @@ export const sponsorsResource = {
     adapter: Adapter,
   ): Promise<Sponsor> => {
     const validatedOptions = baseOptionsSchema.parse(options)
-    if (!models.sponsor.operations.update) throw new Error('Sponsor update operation not found')
+    if (!models.sponsor.operations.update) throw new OperationNotFoundError('Sponsor update operation not found')
     const validatedData = models.sponsor.operations.update.schema.parse(json)
     return adapter.put<Sponsor>({
       json: validatedData,
@@ -805,7 +806,7 @@ export const sponsorLevelsResource = {
     adapter: Adapter,
   ): Promise<SponsorLevel> => {
     const validatedOptions = baseOptionsSchema.parse(options)
-    if (!models.sponsorLevel.operations.create) throw new Error('SponsorLevel create operation not found')
+    if (!models.sponsorLevel.operations.create) throw new OperationNotFoundError('SponsorLevel create operation not found')
     const validatedData = models.sponsorLevel.operations.create.schema.parse(json)
     return adapter.post<SponsorLevel>({
       json: validatedData,
@@ -821,7 +822,7 @@ export const sponsorLevelsResource = {
     adapter: Adapter,
   ): Promise<SponsorLevel> => {
     const validatedOptions = baseOptionsSchema.parse(options)
-    if (!models.sponsorLevel.operations.update) throw new Error('SponsorLevel update operation not found')
+    if (!models.sponsorLevel.operations.update) throw new OperationNotFoundError('SponsorLevel update operation not found')
     const validatedData = models.sponsorLevel.operations.update.schema.parse(json)
     return adapter.put<SponsorLevel>({
       json: validatedData,

--- a/src/schemas/form-field.ts
+++ b/src/schemas/form-field.ts
@@ -32,7 +32,7 @@ export const FormFieldSchema = z.object({
     }),
   order: z.number().meta({
     label: 'Order',
-    description: 'Display order within the form.',
+    description: 'Display order within the form. Defaults to last.',
   }),
   status: z.enum(['created', 'locked', 'deleted']).meta({
     label: 'Status',

--- a/src/schemas/form-field.ts
+++ b/src/schemas/form-field.ts
@@ -14,7 +14,7 @@ export const FormFieldSchema = z.object({
   }),
   name: z.string().meta({
     label: 'Name',
-    description: 'Machine-readable field name (used as key in ticket.values).',
+    description: 'Machine-readable field name (used as key in ticket.values). Immutable after creation.',
   }),
   title: z.string().meta({
     label: 'Title',
@@ -47,46 +47,49 @@ export const FormFieldSchema = z.object({
 })
 
 export const FormFieldCreateSchema = z.object({
-  name: z.string().meta({
-      label: 'Name',
-      description: 'Machine-readable field name (used as key in ticket.values).',
-    }),
+  name: z.string().optional().meta({
+    label: 'Name',
+    description:
+      'Machine-readable field name (used as key in ticket.values). Auto-generated from the title if omitted. Immutable after creation.',
+  }),
   title: z.string().meta({
-      label: 'Title',
-      description: 'Human-readable field label.',
-    }),
+    label: 'Title',
+    description: 'Human-readable field label.',
+  }),
   description: z.string().nullable().optional().meta({
-      label: 'Description',
-      description: 'Optional help text for the field.',
-    }),
+    label: 'Description',
+    description: 'Optional help text for the field.',
+  }),
   field: z
     .enum(['text', 'textarea', 'radio', 'checkbox', 'select', 'country', 'rating', 'section', 'company', 'title'])
     .meta({
-        label: 'Field Type',
-        description: 'The input type of the field.',
-      }),
+      label: 'Field Type',
+      description: 'The input type of the field.',
+    }),
   order: z.number().optional().meta({
-      label: 'Order',
-      description: 'Display order within the form.',
-    }),
+    label: 'Order',
+    description: 'Display order within the form.',
+  }),
   settings: z.looseObject({}).optional().meta({
-      label: 'Settings',
-    }),
+    label: 'Settings',
+  }),
   formId: z.number().meta({
-      label: 'Form Id',
-      description: 'Form this field belongs to.',
-    }),
+    label: 'Form Id',
+    description: 'Form this field belongs to.',
+  }),
   sectionId: z.number().nullable().optional().meta({
-      label: 'Section Id',
-      description: 'Parent section field ID, if nested.',
-    }),
+    label: 'Section Id',
+    description: 'Parent section field ID, if nested.',
+  }),
 })
 
-export const FormFieldUpdateSchema = FormFieldCreateSchema.partial().extend({
-  status: z.enum(['created', 'locked']).optional().meta({
+export const FormFieldUpdateSchema = FormFieldCreateSchema.omit({ name: true })
+  .partial()
+  .extend({
+    status: z.enum(['created', 'locked']).optional().meta({
       label: 'Status',
     }),
-})
+  })
 
 const formFieldsFindAllSchema = {
   filter: z.object({

--- a/src/schemas/ticket.ts
+++ b/src/schemas/ticket.ts
@@ -123,7 +123,10 @@ export const GuestTicketInputSchema = z.object({
   email: z.string().email().optional().meta({ label: 'Email' }),
   phone: z.string().optional().meta({ label: 'Phone' }),
   company: z.string().optional().meta({ label: 'Company' }),
-  values: z.looseObject({}).optional().meta({ label: 'Values' }),
+  values: z.looseObject({}).optional().meta({
+    label: 'Values',
+    description: 'Raw form field answers for this guest, keyed by field name (e.g. {"dietary-needs": "Vegan"}).',
+  }),
 })
 
 export const TicketCreateSchema = z.object({

--- a/src/schemas/ticket.ts
+++ b/src/schemas/ticket.ts
@@ -109,14 +109,16 @@ export const TicketSchema = z.object({
   }),
 })
 
-// A guest ticket attached to a parent ticket. Guests are child tickets, written inline as
-// an array on the parent's create/update payload (mirrors the admin API's data.guestTickets).
-// Omit `id` to add a new guest; include the existing guest's `id` to edit it. Removing a
-// guest is done by deleting that guest's ticket, not by omitting it from the array.
+// A guest ticket attached to a parent ticket. Guests are child tickets, provided inline as an
+// array when creating a parent ticket (mirrors the admin API's data.guestTickets); each entry
+// becomes a new child ticket.
+// NOTE: the API currently only applies guests at create time. Editing an existing guest in place
+// (via `id`) and changing guests on an already-created ticket via update are not honored yet.
+// Removing a guest is done by deleting that guest's ticket.
 export const GuestTicketInputSchema = z.object({
   id: z.coerce.number().optional().meta({
     label: 'Guest Ticket Id',
-    helpText: 'Id of an existing guest ticket to edit. Omit to add a new guest.',
+    helpText: 'Identifies an existing guest ticket. In-place guest editing is not yet supported by the API.',
   }),
   firstName: z.string().optional().meta({ label: 'First name' }),
   lastName: z.string().optional().meta({ label: 'Last name' }),
@@ -222,7 +224,7 @@ export const TicketUpdateSchema = z.object({
   guestTickets: z.array(GuestTicketInputSchema).optional().meta({
     label: 'Guest Tickets',
     description:
-      'Guests attached to this ticket, as an array of guest people. Omit the id to add a guest, include the id to edit an existing one. Removing a guest is done by deleting that guest ticket. Requires the event to have guest info enabled.',
+      'NOTE: guest changes are not yet applied on update — guests can currently only be set when creating a ticket, not added or edited afterwards.',
   }),
 })
 

--- a/src/schemas/ticket.ts
+++ b/src/schemas/ticket.ts
@@ -109,9 +109,6 @@ export const TicketSchema = z.object({
   }),
 })
 
-// A guest provided when creating a ticket. Each entry becomes a new child ticket (mirrors the
-// admin API's data.guestTickets) and requires the event to have guest info enabled. Guests can
-// only be set at create time; editing or removing guests on an existing ticket is not supported yet.
 export const GuestTicketInputSchema = z.object({
   firstName: z.string().optional().meta({ label: 'First name' }),
   lastName: z.string().optional().meta({ label: 'Last name' }),

--- a/src/schemas/ticket.ts
+++ b/src/schemas/ticket.ts
@@ -109,6 +109,23 @@ export const TicketSchema = z.object({
   }),
 })
 
+// A guest ticket attached to a parent ticket. Guests are child tickets, written inline as
+// an array on the parent's create/update payload (mirrors the admin API's data.guestTickets).
+// Omit `id` to add a new guest; include the existing guest's `id` to edit it. Removing a
+// guest is done by deleting that guest's ticket, not by omitting it from the array.
+export const GuestTicketInputSchema = z.object({
+  id: z.coerce.number().optional().meta({
+    label: 'Guest Ticket Id',
+    helpText: 'Id of an existing guest ticket to edit. Omit to add a new guest.',
+  }),
+  firstName: z.string().optional().meta({ label: 'First name' }),
+  lastName: z.string().optional().meta({ label: 'Last name' }),
+  email: z.string().email().optional().meta({ label: 'Email' }),
+  phone: z.string().optional().meta({ label: 'Phone' }),
+  company: z.string().optional().meta({ label: 'Company' }),
+  values: z.looseObject({}).optional().meta({ label: 'Values' }),
+})
+
 export const TicketCreateSchema = z.object({
   eventId: z.coerce.number().meta({
     label: 'Event Id',
@@ -157,6 +174,11 @@ export const TicketCreateSchema = z.object({
     label: 'Send email confirmation',
     helpText: 'If set to true, an email confirmation will be sent to the attendee / invitee.',
   }),
+  guestTickets: z.array(GuestTicketInputSchema).optional().meta({
+    label: 'Guest Tickets',
+    description:
+      'Guests attached to this ticket, as an array of guest people. Each guest becomes a child ticket. Requires the event to have guest info enabled.',
+  }),
 })
 
 export const TicketUpdateSchema = z.object({
@@ -188,6 +210,11 @@ export const TicketUpdateSchema = z.object({
   sendEmailConfirmation: z.boolean().optional().meta({
     label: 'Send email confirmation',
     helpText: 'If set to true, an email confirmation will be sent to the attendee.',
+  }),
+  guestTickets: z.array(GuestTicketInputSchema).optional().meta({
+    label: 'Guest Tickets',
+    description:
+      'Guests attached to this ticket, as an array of guest people. Omit the id to add a guest, include the id to edit an existing one. Removing a guest is done by deleting that guest ticket. Requires the event to have guest info enabled.',
   }),
 })
 
@@ -320,7 +347,7 @@ const ticketsFindAllSchema = {
     .optional(),
   include: z
     .array(
-      z.enum(['addons', 'formattedValues']).meta({
+      z.enum(['addons', 'formattedValues', 'parentTicket', 'guestTickets']).meta({
         label: 'Include Relations',
         description: 'Include related data',
         values: [
@@ -338,6 +365,20 @@ const ticketsFindAllSchema = {
             type: 'string',
             key: 'formattedValues',
             value: 'formattedValues',
+          },
+          {
+            label: 'Parent Ticket',
+            description: 'The parent ticket, if this ticket is a guest of another ticket',
+            type: 'string',
+            key: 'parentTicket',
+            value: 'parentTicket',
+          },
+          {
+            label: 'Guest Tickets',
+            description: 'The guest tickets belonging to this ticket',
+            type: 'string',
+            key: 'guestTickets',
+            value: 'guestTickets',
           },
         ],
       }),

--- a/src/schemas/ticket.ts
+++ b/src/schemas/ticket.ts
@@ -109,17 +109,10 @@ export const TicketSchema = z.object({
   }),
 })
 
-// A guest ticket attached to a parent ticket. Guests are child tickets, provided inline as an
-// array when creating a parent ticket (mirrors the admin API's data.guestTickets); each entry
-// becomes a new child ticket.
-// NOTE: the API currently only applies guests at create time. Editing an existing guest in place
-// (via `id`) and changing guests on an already-created ticket via update are not honored yet.
-// Removing a guest is done by deleting that guest's ticket.
+// A guest provided when creating a ticket. Each entry becomes a new child ticket (mirrors the
+// admin API's data.guestTickets) and requires the event to have guest info enabled. Guests can
+// only be set at create time; editing or removing guests on an existing ticket is not supported yet.
 export const GuestTicketInputSchema = z.object({
-  id: z.coerce.number().optional().meta({
-    label: 'Guest Ticket Id',
-    helpText: 'Identifies an existing guest ticket. In-place guest editing is not yet supported by the API.',
-  }),
   firstName: z.string().optional().meta({ label: 'First name' }),
   lastName: z.string().optional().meta({ label: 'Last name' }),
   email: z.string().email().optional().meta({ label: 'Email' }),
@@ -220,11 +213,6 @@ export const TicketUpdateSchema = z.object({
   sendEmailConfirmation: z.boolean().optional().meta({
     label: 'Send email confirmation',
     helpText: 'If set to true, an email confirmation will be sent to the attendee.',
-  }),
-  guestTickets: z.array(GuestTicketInputSchema).optional().meta({
-    label: 'Guest Tickets',
-    description:
-      'NOTE: guest changes are not yet applied on update — guests can currently only be set when creating a ticket, not added or edited afterwards.',
   }),
 })
 

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -3,7 +3,7 @@
 import type { Category } from '../schemas/category.js'
 import type { Contact, ContactCreate } from '../schemas/contact.js'
 import type { Event, EventCreate, EventUpdate } from '../schemas/event.js'
-import type { Ticket, TicketCreate } from '../schemas/ticket.js'
+import type { Ticket, TicketCreate, TicketUpdate } from '../schemas/ticket.js'
 import type { Payment } from '../schemas/payment.js'
 import type { Webhook, WebhookCreate } from '../schemas/webhook.js'
 import type { Workspace } from '../schemas/workspace.js'
@@ -30,6 +30,7 @@ export type {
   EventUpdate,
   Ticket,
   TicketCreate,
+  TicketUpdate,
   Payment,
   Webhook,
   WebhookCreate,

--- a/test/resources/tickets.ts
+++ b/test/resources/tickets.ts
@@ -131,24 +131,6 @@ describe('Tickets', () => {
 
       assert.deepStrictEqual(data, Confetti.models.ticket.sample.single.formatted)
     })
-    test('should update a ticket with guest tickets', async () => {
-      const mockData = Confetti.models.ticket.sample.single.raw
-
-      nock('https://api.confetti.events')
-        .put('/tickets/1', (body) => {
-          const attributes = (body as { data?: { attributes?: Record<string, unknown> } })?.data?.attributes
-          const guests = attributes?.guestTickets as Array<Record<string, unknown>> | undefined
-          return !!guests && guests.length === 1 && guests[0].id === 42 && guests[0].firstName === 'Edited'
-        })
-        .reply(200, mockData as MockResponseData)
-
-      const confetti = new Confetti({ apiKey: 'my-key' })
-      const data = await confetti.tickets.update(1, {
-        guestTickets: [{ id: 42, firstName: 'Edited' }],
-      })
-
-      assert.deepStrictEqual(data, Confetti.models.ticket.sample.single.formatted)
-    })
   })
 
   describe('Static', () => {

--- a/test/resources/tickets.ts
+++ b/test/resources/tickets.ts
@@ -107,6 +107,48 @@ describe('Tickets', () => {
 
       assert.deepStrictEqual(data, Confetti.models.ticket.sample.single.formatted)
     })
+    test('should create a ticket with guest tickets', async () => {
+      const mockData = Confetti.models.ticket.sample.single.raw
+
+      nock('https://api.confetti.events')
+        .post('/tickets', (body) => {
+          const attributes = (body as { data?: { attributes?: Record<string, unknown> } })?.data?.attributes
+          const guests = attributes?.guestTickets as Array<Record<string, unknown>> | undefined
+          return (
+            !!guests && guests.length === 1 && guests[0].firstName === 'Guest' && guests[0].email === 'guest@doe.se'
+          )
+        })
+        .reply(201, mockData as MockResponseData)
+
+      const confetti = new Confetti({ apiKey: 'my-key' })
+      const data = await confetti.tickets.create({
+        eventId: 1,
+        email: 'john@doe.se',
+        status: 'invited',
+        sendEmailConfirmation: true,
+        guestTickets: [{ firstName: 'Guest', email: 'guest@doe.se' }],
+      })
+
+      assert.deepStrictEqual(data, Confetti.models.ticket.sample.single.formatted)
+    })
+    test('should update a ticket with guest tickets', async () => {
+      const mockData = Confetti.models.ticket.sample.single.raw
+
+      nock('https://api.confetti.events')
+        .put('/tickets/1', (body) => {
+          const attributes = (body as { data?: { attributes?: Record<string, unknown> } })?.data?.attributes
+          const guests = attributes?.guestTickets as Array<Record<string, unknown>> | undefined
+          return !!guests && guests.length === 1 && guests[0].id === 42 && guests[0].firstName === 'Edited'
+        })
+        .reply(200, mockData as MockResponseData)
+
+      const confetti = new Confetti({ apiKey: 'my-key' })
+      const data = await confetti.tickets.update(1, {
+        guestTickets: [{ id: 42, firstName: 'Edited' }],
+      })
+
+      assert.deepStrictEqual(data, Confetti.models.ticket.sample.single.formatted)
+    })
   })
 
   describe('Static', () => {


### PR DESCRIPTION
Adds the `parentTicket` relationship and the `parentTicket` / `guestTickets` includes to the ticket model, and lets ticket `create` carry an inline `guestTickets` array to attach guests (each becomes a child ticket). Guests are set at create time only. The SDK half of exposing ticket guests and parent tickets through the public API and its MCP tools.

### Related PRs
- https://github.com/confetti/confetti-node/pull/30
- https://github.com/confetti/confetti-api/pull/1247
- https://github.com/confetti/confetti-public-api/pull/35
- https://github.com/confetti/yayson/pull/110