### PR TITLE
Add strict event status validation and make website read-only

### DIFF
--- a/src/schemas/event.ts
+++ b/src/schemas/event.ts
@@ -7,6 +7,9 @@ import {
   staticBaseFindOptionsSchema,
 } from './resource-options.js'
 
+const eventStatuses = ['draft', 'open', 'cancelled', 'deleted', 'template'] as const
+const eventSettableStatuses = ['draft', 'open', 'cancelled'] as const
+
 export const EventSchema = z.object({
   id: z.number().meta({
     label: 'ID',
@@ -28,7 +31,7 @@ export const EventSchema = z.object({
   slug: z.string().meta({
     label: 'Slug',
   }),
-  status: z.enum(['draft', 'open', 'cancelled', 'deleted', 'template']).meta({
+  status: z.enum(eventStatuses).meta({
     label: 'Status',
   }),
   featureLevel: z.string().meta({
@@ -55,8 +58,7 @@ export const EventSchema = z.object({
   }),
   privacyPassword: z.string().meta({
     label: 'Privacy password',
-    description:
-      "Password required to view/attend when privacyVisibility or privacyAttendability is 'password'.",
+    description: "Password required to view/attend when privacyVisibility or privacyAttendability is 'password'.",
   }),
   website: z.string().meta({
     label: 'Website',
@@ -160,13 +162,13 @@ export const EventCreateSchema = z.object({
   startDate: z.union([z.date(), z.string()]).meta({ label: 'Start Date' }),
   endDate: z.union([z.date(), z.string()]).optional().meta({ label: 'End Date' }),
   status: z
-    .enum(['draft', 'open', 'cancelled'])
+    .enum(eventSettableStatuses)
     .optional()
     .meta({
       label: 'Status',
       description:
         "Event lifecycle status. 'draft' = unpublished/private, 'open' = published and live, 'cancelled' = cancelled. To publish a draft event, set status to 'open'; to unpublish, set it back to 'draft'. Publishing requires the event owner's account to be verified.",
-      values: ['draft', 'open', 'cancelled'],
+      values: [...eventSettableStatuses],
     }),
   signupType: z.enum(['rsvp', 'tickets']).optional().meta({ label: 'Signup Type' }),
   signupStartAt: z.union([z.date(), z.string()]).optional().meta({ label: 'Signup Start At' }),
@@ -183,8 +185,7 @@ export const EventCreateSchema = z.object({
   }),
   privacyPassword: z.string().optional().meta({
     label: 'Privacy password',
-    description:
-      "Password required to view/attend when privacyVisibility or privacyAttendability is 'password'.",
+    description: "Password required to view/attend when privacyVisibility or privacyAttendability is 'password'.",
   }),
   rsvpLimit: z.number().optional().meta({ label: 'Rsvp Limit' }),
   email: z.string().email().optional().meta({ label: 'Email' }),

--- a/src/schemas/event.ts
+++ b/src/schemas/event.ts
@@ -28,7 +28,7 @@ export const EventSchema = z.object({
   slug: z.string().meta({
     label: 'Slug',
   }),
-  status: z.string().meta({
+  status: z.enum(['draft', 'open', 'cancelled', 'deleted', 'template']).meta({
     label: 'Status',
   }),
   featureLevel: z.string().meta({
@@ -159,7 +159,15 @@ export const EventCreateSchema = z.object({
   name: z.string().meta({ label: 'Name' }),
   startDate: z.union([z.date(), z.string()]).meta({ label: 'Start Date' }),
   endDate: z.union([z.date(), z.string()]).optional().meta({ label: 'End Date' }),
-  status: z.string().optional().meta({ label: 'Status' }),
+  status: z
+    .enum(['draft', 'open', 'cancelled'])
+    .optional()
+    .meta({
+      label: 'Status',
+      description:
+        "Event lifecycle status. 'draft' = unpublished/private, 'open' = published and live, 'cancelled' = cancelled. To publish a draft event, set status to 'open'; to unpublish, set it back to 'draft'. Publishing requires the event owner's account to be verified.",
+      values: ['draft', 'open', 'cancelled'],
+    }),
   signupType: z.enum(['rsvp', 'tickets']).optional().meta({ label: 'Signup Type' }),
   signupStartAt: z.union([z.date(), z.string()]).optional().meta({ label: 'Signup Start At' }),
   signupEndAt: z.union([z.date(), z.string()]).optional().meta({ label: 'Signup End At' }),
@@ -180,7 +188,8 @@ export const EventCreateSchema = z.object({
   }),
   rsvpLimit: z.number().optional().meta({ label: 'Rsvp Limit' }),
   email: z.string().email().optional().meta({ label: 'Email' }),
-  website: z.string().url().optional().meta({ label: 'Website' }),
+  // website is read-only: it is derived from the event's domain server-side and
+  // must not be set by clients. It remains in EventSchema (read) but not here.
   timeZone: z.string().optional().meta({ label: 'Time Zone' }),
   continuous: z.boolean().optional().meta({ label: 'Continuous' }),
   slug: z.string().optional().meta({ label: 'Slug' }),

--- a/src/schemas/event.ts
+++ b/src/schemas/event.ts
@@ -7,8 +7,8 @@ import {
   staticBaseFindOptionsSchema,
 } from './resource-options.js'
 
-const eventStatuses = ['draft', 'open', 'cancelled', 'deleted', 'template'] as const
-const eventSettableStatuses = ['draft', 'open', 'cancelled'] as const
+const EVENT_STATUSES = ['draft', 'open', 'cancelled', 'deleted', 'template'] as const
+const EVENT_SETTABLE_STATUSES = ['draft', 'open', 'cancelled'] as const
 
 export const EventSchema = z.object({
   id: z.number().meta({
@@ -31,7 +31,7 @@ export const EventSchema = z.object({
   slug: z.string().meta({
     label: 'Slug',
   }),
-  status: z.enum(eventStatuses).meta({
+  status: z.enum(EVENT_STATUSES).meta({
     label: 'Status',
   }),
   featureLevel: z.string().meta({
@@ -162,13 +162,13 @@ export const EventCreateSchema = z.object({
   startDate: z.union([z.date(), z.string()]).meta({ label: 'Start Date' }),
   endDate: z.union([z.date(), z.string()]).optional().meta({ label: 'End Date' }),
   status: z
-    .enum(eventSettableStatuses)
+    .enum(EVENT_SETTABLE_STATUSES)
     .optional()
     .meta({
       label: 'Status',
       description:
         "Event lifecycle status. 'draft' = unpublished/private, 'open' = published and live, 'cancelled' = cancelled. To publish a draft event, set status to 'open'; to unpublish, set it back to 'draft'. Publishing requires the event owner's account to be verified.",
-      values: [...eventSettableStatuses],
+      values: [...EVENT_SETTABLE_STATUSES],
     }),
   signupType: z.enum(['rsvp', 'tickets']).optional().meta({ label: 'Signup Type' }),
   signupStartAt: z.union([z.date(), z.string()]).optional().meta({ label: 'Signup Start At' }),

--- a/test/schemas/event.ts
+++ b/test/schemas/event.ts
@@ -1,0 +1,57 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert'
+import { z } from 'zod'
+import { EventCreateSchema, EventUpdateSchema, EventSchema } from '../../src/schemas/event.js'
+
+describe('EventCreateSchema', () => {
+  describe('status', () => {
+    for (const status of ['draft', 'open', 'cancelled']) {
+      test(`should accept writable status "${status}"`, () => {
+        const result = EventCreateSchema.parse({ name: 'My event', startDate: '2026-01-01T12:00:00Z', status })
+        assert.strictEqual(result.status, status)
+      })
+    }
+
+    for (const status of ['published', 'deleted', 'template', 'foo']) {
+      test(`should reject invalid/non-writable status "${status}"`, () => {
+        assert.throws(
+          () => EventCreateSchema.parse({ name: 'My event', startDate: '2026-01-01T12:00:00Z', status }),
+          z.ZodError,
+        )
+      })
+    }
+
+    test('should allow omitting status', () => {
+      const result = EventCreateSchema.parse({ name: 'My event', startDate: '2026-01-01T12:00:00Z' })
+      assert.strictEqual(result.status, undefined)
+    })
+  })
+
+  describe('website (read-only)', () => {
+    test('should strip a client-supplied website on create', () => {
+      const result = EventCreateSchema.parse({
+        name: 'My event',
+        startDate: '2026-01-01T12:00:00Z',
+        website: 'https://evil.example/phish',
+      })
+      assert.ok(!('website' in result))
+    })
+
+    test('should strip a client-supplied website on update', () => {
+      const result = EventUpdateSchema.parse({ website: 'https://evil.example/phish' })
+      assert.ok(!('website' in result))
+    })
+  })
+})
+
+describe('EventSchema (read)', () => {
+  test('should accept every valid stored status, including deleted/template', () => {
+    for (const status of ['draft', 'open', 'cancelled', 'deleted', 'template']) {
+      assert.strictEqual(EventSchema.shape.status.parse(status), status)
+    }
+  })
+
+  test('should reject a non-existent status on read', () => {
+    assert.throws(() => EventSchema.shape.status.parse('published'), z.ZodError)
+  })
+})


### PR DESCRIPTION
## Summary
This PR adds stricter validation for event status fields and makes the website field read-only by removing it from the create/update schemas while keeping it in the read schema.

## Key Changes
- **EventSchema (read)**: Changed `status` from a generic string to a strict enum accepting only valid stored statuses: `'draft'`, `'open'`, `'cancelled'`, `'deleted'`, `'template'`
- **EventCreateSchema**: 
  - Restricted `status` to only writable values: `'draft'`, `'open'`, `'cancelled'` (excludes `'deleted'` and `'template'` which are server-managed)
  - Added comprehensive metadata including description and allowed values for API documentation
  - Removed `website` field entirely to prevent clients from setting it (it's server-derived from the event's domain)
- **Test coverage**: Added comprehensive test suite validating:
  - Writable statuses are accepted on create
  - Non-writable and invalid statuses are rejected on create
  - Website field is stripped from both create and update operations
  - All valid stored statuses are accepted on read
  - Invalid statuses are rejected on read

## Implementation Details
The website field removal uses a comment-based approach to document why it's intentionally omitted from the write schemas, maintaining clarity for future maintainers. The status enum distinction between read and write schemas ensures proper separation of concerns: clients can only set lifecycle-related statuses, while the system manages internal states like `'deleted'` and `'template'`.

https://claude.ai/code/session_01BTS2zHcGS1msp7eKmiqtoJ

### Related PRs
- https://github.com/confetti/confetti-api/pull/1268
- https://github.com/confetti/confetti-public-api/pull/39
- https://github.com/confetti/confetti-node/pull/33